### PR TITLE
convenience methods campaigns.by_name and by_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 doc
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - jruby-19mode
   - rbx-19mode
 
 matrix:
   allow_failures:
     - rvm: 2.0.0
+    - rvm: rbx-19mode

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source "http://rubygems.org"
 
 gem "rake"
-gem "json", "~>1.4.0"
-gem "json_pure", "~>1.4.0"
+gem "json", "~>1.8.0"
+gem "json_pure", "~>1.8.0"
 gem "rdoc"
 
 group :test do
-  gem "rr", "~>1.0"
+  gem "rr", "~>1.1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    json (1.4.6)
-    json (1.4.6-java)
-    json_pure (1.4.6)
-    rake (0.9.2.2)
-    rdoc (3.11)
+    json (1.8.0)
+    json (1.8.0-java)
+    json_pure (1.8.0)
+    rake (10.1.0)
+    rdoc (4.0.1)
       json (~> 1.4)
-    rr (1.0.4)
+    rr (1.1.2)
 
 PLATFORMS
   java
   ruby
 
 DEPENDENCIES
-  json (~> 1.4.0)
-  json_pure (~> 1.4.0)
+  json (~> 1.8.0)
+  json_pure (~> 1.8.0)
   rake
   rdoc
-  rr (~> 1.0)
+  rr (~> 1.1)

--- a/README.rdoc
+++ b/README.rdoc
@@ -59,6 +59,11 @@ Create new contact:
   gr_connection.contacts.create("name" => "John Doe", "email" => "john.d@somewhere.com",
     "campaign" => "campaignId", "customs" => { "source" => "mainpage" })
 
+Get contact by email:
+
+  # with connection
+  contact = gr_connection.contacts.by_email("john.d@somewhere.com")
+
 Update your contact:
 
   # with connection

--- a/README.rdoc
+++ b/README.rdoc
@@ -59,10 +59,10 @@ Create new contact:
   gr_connection.contacts.create("name" => "John Doe", "email" => "john.d@somewhere.com",
     "campaign" => "campaignId", "customs" => { "source" => "mainpage" })
 
-Get contact by email:
+Get contact by email [and optional campaign_id]:
 
   # with connection
-  contact = gr_connection.contacts.by_email("john.d@somewhere.com")
+  contact = gr_connection.contacts.by_email("john.d@somewhere.com", campaign_id=nil)
 
 Update your contact:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -38,6 +38,14 @@ Get your active campaigns.
 
   gr_connection.campaigns.all
 
+Get a specific campaign by name.
+
+  gr_connection.campaigns.by_name('my_campaign_1')
+
+Get a specific campaign by id.
+
+  gr_connection.campaigns.by_id('MY_CAMPAIGN_ID')
+
 You can operate on your contacts quite the same way as on ActiveRecord objects. Before any operation
 on contacts you must connect to API.
 

--- a/getresponse.gemspec
+++ b/getresponse.gemspec
@@ -6,12 +6,12 @@ Gem::Specification.new do |s|
   s.homepage      = "http://dev.getresponse.com"
   s.summary       = "Ruby wrapper for GetResponse API"
   s.description   = "With this gem you can manage your subscribers, campaigns, messages etc."
-  s.version       = "0.6"
+  s.version       = "0.7.0"
 
-  s.add_dependency "json", "~> 1.4"
-  s.add_dependency "json_pure", "~>1.4"
-  s.add_development_dependency "rr", "~>1.0"
-  s.required_rubygems_version = ">= 1.3.5"
+  s.add_dependency "json", "~> 1.8"
+  s.add_dependency "json_pure", "~>1.8"
+  s.add_development_dependency "rr", "~>1.1"
+  s.required_rubygems_version = ">= 1.8.25"
 
   s.files         = Dir.glob("lib/**/*") + %w(README.rdoc)
   s.require_path  = "lib"

--- a/lib/get_response.rb
+++ b/lib/get_response.rb
@@ -5,6 +5,7 @@ module GetResponse
 end
 
 GetResponse.autoload :GetResponseError, "get_response/get_response_error"
+GetResponse.autoload :GRNotFound, "get_response/get_response_error"
 GetResponse.autoload :Account, "get_response/account"
 GetResponse.autoload :Campaign, "get_response/campaign"
 GetResponse.autoload :Connection, "get_response/connection"

--- a/lib/get_response/campaign_proxy.rb
+++ b/lib/get_response/campaign_proxy.rb
@@ -12,9 +12,45 @@ module GetResponse
     #
     # returns:: Array of GetResponse::Campaign
     def all
-      response = @connection.send_request("get_campaigns", {})["result"]
-      response.inject([]) do |campaigns, resp|
-        campaigns << Campaign.new(resp[1].merge("id" => resp[0]), @connection)
+      response = @connection.send_request('get_campaigns', {})['result']
+      response.inject([]) do |campaigns, (key,value)|
+        campaigns << Campaign.new(value.merge('id' => key), @connection)
+      end
+    end
+
+
+    # Get campaign by id
+    #
+    # returns:: Array of Getresponse::Campaign
+    #
+    def by_id(campaign_id)
+      response = @connection.send_request('get_campaign',
+                                          { 'campaign' => campaign_id }
+                                         ) 
+
+      if response['result'].empty?
+        raise GRNotFound.new("Campaign not found: #{campaign_id}")
+      else
+        attrs = response['result'].values.first.merge('id' => response['result'].keys.pop)
+        Campaign.new(attrs, @connection)
+      end
+    end
+
+    # Get campaign by name
+    # getresponse API states:
+    # "There can be only one campaign of a given name" 
+    #
+    # returns:: instance of Getresponse::Campaign
+    #
+    def by_name(campaign_name)
+      response = @connection.send_request('get_campaigns', 
+                                          { 'name' =>  { 'EQUALS' => campaign_name } }
+                                         )
+      if response['result'].empty?
+        raise GRNotFound.new("Campaign not found: #{campaign_name}")
+      else
+        attrs = response['result'].values.first.merge('id' => response['result'].keys.pop)
+        Campaign.new(attrs, @connection)
       end
     end
 

--- a/lib/get_response/campaign_proxy.rb
+++ b/lib/get_response/campaign_proxy.rb
@@ -21,7 +21,7 @@ module GetResponse
 
     # Get campaign by id
     #
-    # returns:: Array of Getresponse::Campaign
+    # returns:: instance of Getresponse::Campaign
     #
     def by_id(campaign_id)
       response = @connection.send_request('get_campaign',

--- a/lib/get_response/campaign_proxy.rb
+++ b/lib/get_response/campaign_proxy.rb
@@ -18,10 +18,10 @@ module GetResponse
       end
     end
 
-
+    
     # Get campaign by id
     #
-    # returns:: instance of Getresponse::Campaign
+    # returns:: Array of Getresponse::Campaign
     #
     def by_id(campaign_id)
       response = @connection.send_request('get_campaign',
@@ -52,24 +52,6 @@ module GetResponse
         attrs = response['result'].values.first.merge('id' => response['result'].keys.pop)
         Campaign.new(attrs, @connection)
       end
-    end
-
-
-    def campaign_by_id(campaign_id)
-    end
-
-    def campaign_by_name(campaign_name)
-      response = @connection.send_request('get_campaigns', 
-                                          { name: { 'EQUALS' => campaign_name } }
-                                         )
-      result = response['result']
-      puts " --------- "
-      pp response
-      puts " --------- "
-      pp result
-
-      response
-
     end
 
 

--- a/lib/get_response/campaign_proxy.rb
+++ b/lib/get_response/campaign_proxy.rb
@@ -63,8 +63,10 @@ module GetResponse
                                           { name: { 'EQUALS' => campaign_name } }
                                          )
       result = response['result']
-      puts response.inspect
-      puts result.inspect
+      puts " --------- "
+      pp response
+      puts " --------- "
+      pp result
     end
 
 

--- a/lib/get_response/campaign_proxy.rb
+++ b/lib/get_response/campaign_proxy.rb
@@ -55,6 +55,19 @@ module GetResponse
     end
 
 
+    def campaign_by_id(campaign_id)
+    end
+
+    def campaign_by_name(campaign_name)
+      response = @connection.send_request('get_campaigns', 
+                                          { name: { 'EQUALS' => campaign_name } }
+                                         )
+      result = response['result']
+      puts response.inspect
+      puts result.inspect
+    end
+
+
     # Create new campaign from passed attributes
     #
     # @param attrs [Hash]

--- a/lib/get_response/campaign_proxy.rb
+++ b/lib/get_response/campaign_proxy.rb
@@ -67,6 +67,9 @@ module GetResponse
       pp response
       puts " --------- "
       pp result
+
+      response
+
     end
 
 

--- a/lib/get_response/contact_proxy.rb
+++ b/lib/get_response/contact_proxy.rb
@@ -22,6 +22,22 @@ module GetResponse
       build_contacts(response["result"])
     end
 
+    # Get contact by name
+    #
+    # returns:: instance of Getresponse::Contact
+    #
+    def by_email(email_address)
+      response = @connection.send_request('get_contacts', 
+                                          { 'email' =>  { 'EQUALS' => email_address } }
+                                         )
+      if response['result'].empty?
+        raise GRNotFound.new("Contact not found: #{email_address}")
+      else
+        attrs = response['result'].values.first.merge('id' => response['result'].keys.pop)
+        Contact.new(attrs, @connection)
+      end
+    end
+
 
     # Create new contact. Method can raise <tt>GetResponseError</tt>.
     #

--- a/lib/get_response/contact_proxy.rb
+++ b/lib/get_response/contact_proxy.rb
@@ -23,12 +23,14 @@ module GetResponse
     end
 
     # Get contact by name
+    # optional limit query to given campaign_id
     #
     # returns:: instance of Getresponse::Contact
+    # raises GRNotFound if empty result returned
     #
-    def by_email(email_address)
+    def by_email(email_address, campaign_id=nil)
       response = @connection.send_request('get_contacts', 
-                                          { 'email' =>  { 'EQUALS' => email_address } }
+                                          build_email_campaign_options(email_address, campaign_id)
                                          )
       if response['result'].empty?
         raise GRNotFound.new("Contact not found: #{email_address}")
@@ -93,6 +95,16 @@ module GetResponse
 
     private
 
+    def build_email_campaign_options(email, campaign_id=nil)
+      email_hash = { 'email' => { 'EQUALS' => email} }
+      ret = if campaign_id
+              { 'campaigns' => [campaign_id] }.merge(email_hash) 
+            else
+              email_hash
+            end
+      return ret
+    end
+    
     # Build collection of <tt>Contact</tt> objects from service response.
     #
     # @param raw_contacts [Array] of Hashes parsed from GetResponse API response

--- a/lib/get_response/get_response_error.rb
+++ b/lib/get_response/get_response_error.rb
@@ -2,4 +2,10 @@
 module GetResponse
   class GetResponseError < StandardError
   end
+
+  # raised in case campaigns.by_name(name) or campaigns.by_id(id) returns 
+  # empty result
+  #
+  class GRNotFound < StandardError
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,8 +8,6 @@ require 'rr'
 
 class Test::Unit::TestCase
 
-  include RR::Adapters::TestUnit
-
 
   protected
 

--- a/test/unit/campaign_proxy_test.rb
+++ b/test/unit/campaign_proxy_test.rb
@@ -43,6 +43,39 @@ class GetResponse::CampaignProxyTest < Test::Unit::TestCase
     assert_not_nil result.id
   end
 
+  def test_by_name
+    request_params = { 'name' => { 'EQUALS' => 'my_campaign_1' } }
+    mock(@connection).send_request('get_campaigns', request_params) { campaign_found_response }
+    result = @proxy.by_name('my_campaign_1')
+    assert_kind_of GetResponse::Campaign, result
+    assert result.name == 'my_campaign_1'
+  end
+
+
+  def test_by_id
+    request_params = { 'campaign' => 'CAMPAIGN_ID'}
+    mock(@connection).send_request('get_campaign', request_params) { campaign_found_response }
+    result = @proxy.by_id('CAMPAIGN_ID')
+    assert_kind_of GetResponse::Campaign, result
+    assert result.id == 'CAMPAIGN_ID'
+    assert result.name == 'my_campaign_1'
+  end
+
+  def test_by_id_raise
+    request_params = { 'campaign' => 'NIL_CAMPAIGN_ID'}
+    mock(@connection).send_request('get_campaign', request_params) { campaign_not_found_response }
+    assert_raise GetResponse::GRNotFound do
+      result = @proxy.by_id('NIL_CAMPAIGN_ID')
+    end 
+  end
+
+  def test_by_name_raise
+    request_params = { 'name' => { 'EQUALS' => 'NIL_CAMPAIGN_NAME' } }
+    mock(@connection).send_request('get_campaigns', request_params) { campaign_not_found_response }
+    assert_raise GetResponse::GRNotFound do
+      result = @proxy.by_name('NIL_CAMPAIGN_NAME')
+    end
+  end
 
   protected
 
@@ -54,6 +87,29 @@ class GetResponse::CampaignProxyTest < Test::Unit::TestCase
         "added" => 1
       },
       "errors" => nil
+    }
+  end
+
+  def campaign_found_response
+    {
+      'result' => {
+        "CAMPAIGN_ID" => {
+          "name" => "my_campaign_1",
+          "description" => "My campaign",
+          "optin" => "single",
+          "from_name" => "My From Name",
+          "from_email" => "me@emailaddress.com",
+          "reply_to_email" => "replies@emailaddress.com",
+          "created_on" => "2010-01-01 00:00:00"
+          }
+        }
+      }
+
+  end
+
+  def campaign_not_found_response
+    {
+    'result' => {} 
     }
   end
 end

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -2,7 +2,6 @@ require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
 
 class GetResponse::ConnectionTest < Test::Unit::TestCase
 
-  include RR::Adapters::TestUnit
 
   def setup
     @gr_connection = GetResponse::Connection.new("my_secret_api_key")

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -2,8 +2,6 @@ require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
 
 class ContactTest < Test::Unit::TestCase
 
-  include RR::Adapters::TestUnit
-
 
   def setup
     @gr_connection = GetResponse::Connection.new("my_secret_api_key")


### PR DESCRIPTION
hi sebastian,
had the need to have some convenient methods to retrieve campaign by name and id - 
also experienced some trouble getting json-1.4 built on my machine. so i bumped json to 1.8 

introduce campaigns.by_name and campaigns.by_id
rip obsolete include RR::Adapters...
adopt gemspec to reflect gem updates - bump version to 0.7
new GRNotFound exception, 
adopt unit-tests
