### PR TITLE
Please add contact.click API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source "http://rubygems.org"
 
 gem "rake"
-gem "json", "~>1.4.0"
+gem "json", "~>1.4"
 gem "json_pure", "~>1.4.0"
 gem "rdoc"
+gem "iconv"
 
 group :test do
   gem "rr", "~>1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    json (1.4.6)
-    json (1.4.6-java)
+    iconv (1.0.4)
+    json (1.8.1)
+    json (1.8.1-java)
     json_pure (1.4.6)
     rake (0.9.2.2)
     rdoc (3.11)
@@ -14,7 +15,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  json (~> 1.4.0)
+  iconv
+  json (~> 1.4)
   json_pure (~> 1.4.0)
   rake
   rdoc

--- a/lib/get_response/contact.rb
+++ b/lib/get_response/contact.rb
@@ -136,6 +136,14 @@ module GetResponse
       @connection.send_request("get_contact_opens", param)["result"]
     end
 
+    # List dates when links were clicked by contact. If a contact clicked the same link multiple
+    # times, only the newest date is listed.
+    # returns:: Hash
+    def clicks
+      param = {"contact" => @id}
+      @connection.send_request("get_contact_clicks", param)["result"]
+    end
+
 
     # Set contact name. Method can raise <tt>GetResponseError</tt> exception.
     #

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -159,6 +159,15 @@ class ContactTest < Test::Unit::TestCase
     assert_equal 2, resp.keys.size
   end
 
+  def test_clicks
+    mock(@mocked_response).body { contact_clicks_response }
+    contact = new_contact
+    resp = contact.clicks
+
+    assert_kind_of Hash, resp
+    assert_equal 3, resp.keys.size
+  end
+
 
   def test_set_name_exception
     mock(@mocked_response).body { set_contact_name_exception_response }
@@ -277,6 +286,17 @@ class ContactTest < Test::Unit::TestCase
         "message_id_2" => (Time.now - (2 * 24 * 60 * 60)).to_s
       },
       "error" => nil
+    }.to_json
+  end
+
+  def contact_clicks_response
+    {
+        "result" => {
+            "link_id_1" => (Time.now - (1 * 24 * 60 * 60)).to_s,
+            "link_id_2" => (Time.now - (2 * 24 * 60 * 60)).to_s,
+            "link_id_3" => (Time.now - (2 * 24 * 60 * 60)).to_s
+        },
+        "error" => nil
     }.to_json
   end
 


### PR DESCRIPTION
I added an implementation for the clicks api to contacts.rb. It uses the get_contact_clicks API very much the same way as contact.opens.

I had to modify the Gemfile to make it work with ruby 2.0.

Tests are green with ruby 1.9.3, 2.0 and 2.1

Thanks
