### PR TITLE
Adding set_customs according to getresponse api

### DIFF
--- a/lib/get_response/contact.rb
+++ b/lib/get_response/contact.rb
@@ -125,6 +125,7 @@ module GetResponse
     # returns:: Hash
     def customs=(value)
       @customs = parse_customs(value)
+      @connection.send_request("set_contact_customs", { "contact" => @id, "customs" => @customs })["result"]
     end
 
 


### PR DESCRIPTION
I tried to update customs on an existing contact, and the implemented method returned "contact already exists" because it's using the create_contact call.
